### PR TITLE
Fixes for docker on Mac OS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:latest
 MAINTAINER Chris Mutzel <chris.mutzel@gmail.com>
 RUN apt-get update # Fri Oct 24 13:09:23 EDT 2014
+FROM ubuntu:14.04
 RUN apt-get -y upgrade
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install mysql-client mysql-server apache2 libapache2-mod-php5 pwgen python-setuptools vim-tiny php5-mysql  php5-ldap unzip
 RUN easy_install supervisor

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 #mysql has to be started this way as it doesn't work to call from /etc/init.d
-/usr/bin/mysqld_safe & 
+#and files need to be touched to overcome overlay file system issues on Mac and Windows
+find /var/lib/mysql -type f -exec touch {} \; && /usr/bin/mysqld_safe & 
 sleep 10s
 # Here we generate random passwords (thank you pwgen!). The first two are for mysql users, the last batch for random keys in wp-config.php
 MYSQL_USER="root"
@@ -14,10 +15,9 @@ HACKAZON_PASSWORD='hackmesilly'
 echo hackazon password: $HACKAZON_PASSWORD
 echo $MYSQL_PASSWORD > /mysql-root-pw.txt
 echo $HACKAZON_PASSWORD > /hackazon-db-pw.txt
-#there used to be a huge ugly line of sed and cat and pipe and stuff below,
-#but thanks to @djfiander's thing at https://gist.github.com/djfiander/6141138
-#there isn't now.
 
+#set DB password in db.php
+sed -i "s/yourdbpass/$HACKAZON_PASSWORD/" /var/www/hackazon/assets/config/db.php
 mysqladmin -u root password $MYSQL_PASSWORD
 mysql -uroot -p$MYSQL_PASSWORD -e "CREATE DATABASE $HACKAZON_DB; GRANT ALL PRIVILEGES ON $HACKAZON_DB.* TO '$HACKAZON_USER'@'localhost' IDENTIFIED BY '$HACKAZON_PASSWORD'; FLUSH PRIVILEGES;"
 killall mysqld


### PR DESCRIPTION
Files need to be touched on docker on Mac and windows due to them using the overlay file system.  The filesystem issue prevents mysql from booting if the files aren't touched first.

Also, switch the docker base build to 14.0.4 as php5 is not available on 16.0.4+.